### PR TITLE
updating wsgi.py to make server available externally

### DIFF
--- a/wsgi.py
+++ b/wsgi.py
@@ -3,4 +3,4 @@
 from run import WALNUT as application
 
 if __name__ == "__main__":
-    application.run()
+    application.run(host="0.0.0.0")


### PR DESCRIPTION
Following configuration outlined in this tutorial: https://www.digitalocean.com/community/tutorials/how-to-serve-flask-applications-with-uwsgi-and-nginx-on-centos-7#set-up-a-flask-application

To test/verify: Check against the `wsgi.py` file in the walnut directory currently in GCP.